### PR TITLE
Add support for membrane segments

### DIFF
--- a/src/RcsbAnnotationConfig/RcsbAnnotationMap.json
+++ b/src/RcsbAnnotationConfig/RcsbAnnotationMap.json
@@ -32,6 +32,10 @@
     "SCOP",
     "MOLECULE_PROCESSING",
     "MEMBRANE_TOPOLOGY",
+    "TRANSMEMBRANE_REGION",
+    "INTRAMEMBRANE_REGION",
+    "TOPOLOGICAL_DOMAIN",
+    "MEMBRANE_SEGMENT",
     "CHAIN",
     "INITIATOR_METHIONINE",
     "SEQUENCE_VARIANT",
@@ -49,10 +53,6 @@
     "SHORT_SEQUENCE_MOTIF",
     "ZINC_FINGER_REGION",
     "PROPEPTIDE",
-    "TRANSMEMBRANE_REGION",
-    "INTRAMEMBRANE_REGION",
-    "MEMBRANE_SEGMENT",
-    "TOPOLOGICAL_DOMAIN",
     "COILED_COIL_REGION",
     "REPEAT",
     "DOMAIN",
@@ -371,7 +371,8 @@
     "type": "MEMBRANE_SEGMENT",
     "display": "block",
     "color": "#8fc50f",
-    "title": "MEMBRANE SEGMENT"
+    "title": "MEMBRANE SEGMENT",
+    "displayCooccurrence": true
   },{
     "type": "REPEAT",
     "display": "block",

--- a/src/RcsbAnnotationConfig/RcsbAnnotationMap.json
+++ b/src/RcsbAnnotationConfig/RcsbAnnotationMap.json
@@ -51,6 +51,7 @@
     "PROPEPTIDE",
     "TRANSMEMBRANE_REGION",
     "INTRAMEMBRANE_REGION",
+    "MEMBRANE_SEGMENT",
     "TOPOLOGICAL_DOMAIN",
     "COILED_COIL_REGION",
     "REPEAT",
@@ -366,6 +367,11 @@
     "display": "block",
     "color": "#8fc50f",
     "title": "TRANSMEMBRANE REGION"
+  },{
+    "type": "MEMBRANE_SEGMENT",
+    "display": "block",
+    "color": "#8fc50f",
+    "title": "MEMBRANE SEGMENT"
   },{
     "type": "REPEAT",
     "display": "block",


### PR DESCRIPTION
Adds support for annotations from OPM & PDBTM and displays them below the UniProt annotations.
Will render like this:
![saguaro](https://user-images.githubusercontent.com/9744615/119736224-429a9000-be32-11eb-8cad-2f70814659c6.png)
